### PR TITLE
comment and code cleanup, #pragma region, addExtension, test_addExtension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,8 @@
                 "tests/CuTest.c",
                 "tests/file_util_test.c",
                 "tests/main_test.c",
-                "-otests"
+                "-otests",
+                "-ansi"
             ],
             "group": {
                 "kind": "test",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 
 
+1/21/2023 : klm127
+- added #pragma region directives to header files. This is basically just markup for VSCode. Each of these regions can now be folded in Visual Studio or VSCode. This does not affect -ansi compilation on MinGW-W64 gcc; as far as I can tell. The purpose is to make the code much easier to navigate without relying on tab-based folding. [See Also: stackoverflow answer](https://stackoverflow.com/questions/63512637/what-is-pragma-region-in-c-and-vscode)
+- Cleaned up comments, tab-based folding, etc.
+- Fixed up the `addExtension` to use malloc to create a longer, concatenated string out of its inputs. Added unit tests for `addExtension`. 
+
+
+1/20/2023 : All group members in collaboration
+- created `promptUserOverwriteSelection`.
+- created tests for `promptUserOverwriteSelection`. This was quite an involved task because we had to figure out how to temporarily replace stdin and stdout with alternative files so that we could test functionalities like `scanf`. Ultimately we were able to figure it out. 
+
+
 1/19/2023 : klm127
 
 - changed directory structure, added docs, src, and tests

--- a/runTests.bat
+++ b/runTests.bat
@@ -1,5 +1,5 @@
 @Echo off
 REM this is handled by VSCode test task but is replicated here for those not using VSCode.
 @Echo on
-gcc -Isrc src/file_util.c tests/CuTest.c tests/file_util_test.c tests/main_test.c -otests
+gcc -Isrc src/file_util.c tests/CuTest.c tests/file_util_test.c tests/main_test.c -otests -ansi
 tests

--- a/src/file_util.c
+++ b/src/file_util.c
@@ -11,9 +11,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stdbool.h>
+#include <string.h>
 #include "file_util.h"
+
+
+#pragma region filenames
 
 short fileExists(const char * filename) {
     FILE * file = fopen(filename, "r");
@@ -55,6 +58,18 @@ int filenameHasExtension(const char * filename) {
     return return_value;
 }
 
+char * addExtension(const char* filename, const char* extension) {
+    /* reallocate memory for a string large enough to hold filename + '.' + extension. */
+    char * new_string = (char *) malloc (sizeof(char) * (strlen(filename) + strlen(extension) + 1));
+    strcpy(new_string, filename);
+    strcat(new_string, ".");
+    strcat(new_string, extension);
+    return new_string;
+}
+
+#pragma endregion filenames
+
+#pragma region prompts
 
 short promptUserOverwriteSelection() {
     int user_selection = 0;
@@ -74,3 +89,5 @@ short promptUserOverwriteSelection() {
         }
     return (short) user_selection;
 }
+
+#pragma endregion prompts

--- a/src/file_util.h
+++ b/src/file_util.h
@@ -2,7 +2,7 @@
   * 
   * Author: Tom Terhune
   * Author: Karl Miller
-  * Author: Anthony Stepich
+  * Author: Anthony Stepich  
   * 
   * program 1 for CSC 460.
   * 
@@ -15,10 +15,11 @@
 #include <stdbool.h>
 
 /* 
-    -------------------------------------------------------------------------------
-    |           Globally Accesible struct                                         |
-    -------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+                Globally Accesible struct(s)                                       
+-------------------------------------------------------------------------------
 */
+#pragma region structs
 
 /*
     CompFile is a globally accesible struct which maintains references to the loaded files.
@@ -32,76 +33,108 @@ struct TCompFile {
 };
 struct TCompFile CompFile;
 
+#pragma endregion structs
+
 /* 
-    -------------------------------------------------------------------------------
-    |           filename functions                                                |
-    -------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+                filename functions                                                
+-------------------------------------------------------------------------------
 */
+#pragma region filenames
 
-    /*
-        fileExists checks whether a file given by filename exists.
+/*
+    fileExists checks whether a file given by filename exists.
 
-        parameters:
-            - char * filename : the filename to check.
-        returns short:
-            - 1 if the file exists.
-            - 0 if the file does not exist.
+    parameters:
+        - char * filename : the filename to check.
+    returns short:
+        - 1 if the file exists.
+        - 0 if the file does not exist.
 
-                        Authors:    klm127
-                        Created On: 1/19/2023
-                        Covered by Unit Tests
+                    Authors:    klm127
+                    Created On: 1/19/2023
+                    Covered by Unit Tests
 
-    */
-    short fileExists(const char * filename);
-
-    /*
-        The enum FILENAME_EXTENSION_PARSE describes possible return values from filenameHasExtension which indicate different ways which a filename may be invalid.
-            no period :         -1
-            ends in period:     -2
-            starts with period: -3
-    */
-    enum FILENAME_EXTENSION_PARSE {
-        FILENAME_HAS_NO_PERIOD = -1,
-        FILENAME_ENDS_IN_PERIOD = -2,
-        FILENAME_STARTS_WITH_PERIOD = -3
-    };
-
-    /*
-        filenameHasExtension checks whether a filename has an extension. In other words, it checks whether a string has a '.' preceded and followed by at least one character.
-
-        parameters:
-            - char * filename : the string to check
-
-        returns int:
-            - the index of the '.' character in the string if it exists.
-            otherwise, one of the negative FILE_EXTENSION_PARSE enums indicating why the filename is invalid;
-                (-1) means there was no period.
-                (-2) means it ended in a period.
-                (-3) means it started with a period.
-
-                        Authors:    klm127
-                        Created On: 1/19/2023
-                        Covered by Unit Tests
-
-    */
-    int filenameHasExtension(const char * filename);
-
-
-
-
-
-/**
- * function: void addExtension
- * 
- * addExtension modifies the string given by filename by concatenating the string given by extension.
- * 
- * Parameters:
- *   char * filename - the char array to modify
- *   char * extension - the char array to append
- * 
- * 
 */
-void addExtension(char* filename, char* extension);
+short fileExists(const char * filename);
+
+/*
+    The enum FILENAME_EXTENSION_PARSE describes possible return values from filenameHasExtension which indicate different ways which a filename may be invalid.
+        no period :         -1
+        ends in period:     -2
+        starts with period: -3
+*/
+enum FILENAME_EXTENSION_PARSE {
+    FILENAME_HAS_NO_PERIOD = -1,
+    FILENAME_ENDS_IN_PERIOD = -2,
+    FILENAME_STARTS_WITH_PERIOD = -3
+};
+
+/*
+    filenameHasExtension checks whether a filename has an extension. In other words, it checks whether a string has a '.' preceded and followed by at least one character.
+
+    parameters:
+        - char * filename : the string to check
+
+    returns int:
+        - the index of the '.' character in the string if it exists.
+        otherwise, one of the negative FILE_EXTENSION_PARSE enums indicating why the filename is invalid;
+            (-1) means there was no period.
+            (-2) means it ended in a period.
+            (-3) means it started with a period.
+
+                    Authors:    klm127
+                    Created On: 1/19/2023
+                    Covered by Unit Tests
+
+*/
+int filenameHasExtension(const char * filename);
+
+
+/*
+    addExtension modifies the string given by filename by concatenating the string given by extension.
+
+    addExtension returns a pointer to a new, concatenated string. This string is allocated with `malloc`. When you are done with it, the memory should be cleared with `free` to avoid memory leaks.
+    
+    parameters:
+        char * filename - the char array to modify
+        char * extension - the char array to append
+
+                    Authors:    thomasterh99, klm127
+                    Created On: 1/18/2023
+                    Covered by Unit Tests
+*/
+char * addExtension(const char* filename, const char* extension);
+
+#pragma endregion filenames
+
+/* 
+-------------------------------------------------------------------------------
+                prompt functions                                                
+-------------------------------------------------------------------------------
+*/
+#pragma region prompts
+enum USER_OUTPUT_OVERWRITE_SELECTION {
+    USER_OUTPUT_OVERWRITE_REENTER_FILENAME_SELECTED = 1,
+    USER_OUTPUT_OVERWRITE_OVERWRITE_EXISTING_FILE = 2,
+    USER_OUTPUT_OVERWRITE_DEFAULT_FILENAME = 3,
+    USER_OUTPUT_TERMINATE_PROGRAM = 4,
+    USER_OUTPUT_TERMINATE_INVALID_ENTRY = -1
+};
+/*
+    promptUserOverwriteSelection prompts the user as to what they want to do about an output file already existing. It prints a prompt and parses the user response to one of the USER_OUTPUT_OVERWRITE_SELECTION enums. It does NOT loop.
+
+    returns short corresponding to one of the enums of USER_OTUPUT_OVERWRITE_SELECTION
+
+                    Authors:    klm127, thomasterh99, anthony91501
+                    Created On: 1/20/2023
+                    Covered by Unit Tests
+
+*/
+short promptUserOverwriteSelection();
+#pragma endregion prompts
+
+
 
 /**
  * function: bool hasExtension
@@ -156,31 +189,6 @@ bool openInputFile(char* inputFilename, FILE* inputFile);
  * 
 */
 void openOutputFile(char* outputFilename, FILE* outputFile);
-
-
-/* 
-    -------------------------------------------------------------------------------
-    |           prompt functions                                                |
-    -------------------------------------------------------------------------------
-*/
-enum USER_OUTPUT_OVERWRITE_SELECTION {
-    USER_OUTPUT_OVERWRITE_REENTER_FILENAME_SELECTED = 1,
-    USER_OUTPUT_OVERWRITE_OVERWRITE_EXISTING_FILE = 2,
-    USER_OUTPUT_OVERWRITE_DEFAULT_FILENAME = 3,
-    USER_OUTPUT_TERMINATE_PROGRAM = 4,
-    USER_OUTPUT_TERMINATE_INVALID_ENTRY = -1
-};
-/*
-    promptUserOverwriteSelection prompts the user as to what they want to do about an output file already existing. It prints a prompt and parses the user response to one of the USER_OUTPUT_OVERWRITE_SELECTION enums. It does NOT loop.
-
-    returns short corresponding to one of the enums of USER_OTUPUT_OVERWRITE_SELECTION
-
-                    Authors:    klm127
-                    Created On: 1/20/2023
-                    Covered by Unit Tests
-
-*/
-short promptUserOverwriteSelection();
 
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -13,9 +13,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-void addExtension(char* filename, char* extension) {
-    strcat(filename, extension);
-}
+
 
 bool hasExtension(char* filename){
 	bool Extension_Found = false;
@@ -35,7 +33,17 @@ bool promptFileName(char* fileName) {
 	size_t bufsize = 100;
 
 	/*scan for filename*/
-	getline(&fileName,&bufsize, stdin);
+	
+
+	/*
+		Note, I have commented out getline for now, but it needs to be removed.
+
+		getline was added around 2010 and, if getline is used, the code will not compile with the -ansi flag (which limits us to 1990 C).
+
+		-K
+	
+	*/
+	/*getline(&fileName,&bufsize, stdin);*/
 	/*if filename is null*/
 	if (fileName[0] == '\0'){
 		flag = false;


### PR DESCRIPTION
Summary of changes (from `changelog.md`):

- added #pragma region directives to header files. This is basically just markup for VSCode. Each of these regions can now be folded in Visual Studio or VSCode. This does not affect -ansi compilation on MinGW-W64 gcc; as far as I can tell. The purpose is to make the code much easier to navigate without relying on tab-based folding. [See Also: stackoverflow answer](https://stackoverflow.com/questions/63512637/what-is-pragma-region-in-c-and-vscode)
- Cleaned up comments, removed tab-based folding, etc.
- Fixed up the `addExtension` to use malloc to create a longer, concatenated string out of its inputs. Added unit tests for `addExtension`. 