### PR TITLE
removeExtension, fixed prompt, backupFile, fixed filenameHasExtension

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "Win32",
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:/Program Files/CodeBlocks/MinGW/include"
+                "C:/Program Files (x86)/Dev-Cpp/MinGW64/lib/gcc/x86_64-w64-mingw32/4.9.2/include"
             ],
             "defines": [
                 "_DEBUG",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "dirent.h": "c"
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,11 @@
+
+
+## Compiling
+
+Compiler configurations are stored in the .bat files. There are two of them. runTests.bat compiles and runs the tests. compile.bat compiles and runs the code. 
+
+## Included 3rd party library, CuTest.
+
+[Link to Cutest page](https://cutest.sourceforge.net/)
+
+This is a small bit of code (only 340 lines!) that provides a unit testing skeleton. 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 
 
+1/22/2023 : thomas and klm127
+ - added removeExtension function and tests
+ - confirmed getchar will read an 'enter'. 
+ - thomas fixed prompting function to accept alternate inputs
+ - added backupFile function and tests
+ - Included tests for filepaths with directories
+ - redid filenameHasExtension. It now allows for filenames like ".bob" and doesnt allow filenames that end in slashes. It does allow folders to have '.'s in them.
+
+
 1/21/2023 : klm127
 - added #pragma region directives to header files. This is basically just markup for VSCode. Each of these regions can now be folded in Visual Studio or VSCode. This does not affect -ansi compilation on MinGW-W64 gcc; as far as I can tell. The purpose is to make the code much easier to navigate without relying on tab-based folding. [See Also: stackoverflow answer](https://stackoverflow.com/questions/63512637/what-is-pragma-region-in-c-and-vscode)
 - Cleaned up comments, tab-based folding, etc.

--- a/src/file_util.c
+++ b/src/file_util.c
@@ -16,7 +16,7 @@
 #include "file_util.h"
 
 
-#pragma region filenames
+#pragma region fileops
 
 short fileExists(const char * filename) {
     FILE * file = fopen(filename, "r");
@@ -28,7 +28,78 @@ short fileExists(const char * filename) {
     }
 }
 
+void backupFile(const char * filename) {
+    short doesFileExist = fileExists(filename);
+    if(doesFileExist == FILE_EXISTS) {
+        char * new_name = addExtension(filename, "bak");
+        rename(filename, new_name);
+        free(new_name);
+        remove(filename);
+    }
+}
+#pragma endregion fileops
+
+#pragma region filenames
+
 int filenameHasExtension(const char * filename) {
+    int return_v;
+    /* Get a pointer to the last slash character in the filename, either a forward or backward slash. */
+    char * p_last_fslash = strrchr(filename, '/');
+    char * p_last_bslash = strrchr(filename, '\\');
+    char * p_last_slash = ((char*) filename) - 1; /* Initialize last slash to an imaginary character preceding the filename. */
+    /* Set last slash to whichever slash came last, if any. */
+    if(p_last_fslash != NULL || p_last_bslash != NULL) {
+        if(p_last_fslash == NULL) {
+            p_last_slash = p_last_bslash;
+        } else if (p_last_bslash == NULL) {
+            p_last_slash = p_last_fslash;
+        } else if (p_last_bslash > p_last_fslash) {
+            p_last_slash = p_last_bslash;
+        } else {
+            p_last_slash = p_last_fslash;
+        }
+    }
+    int slash_index = p_last_slash - filename;
+    if(slash_index == strlen(filename) - 1) {
+        /* if it ends in a '/', it's a directory not a file. */
+        return_v = FILENAME_IS_DIRECTORY;
+    } else {
+        /* Get a pointer to the last period in the filename. */
+        char * p_last_period = strrchr(filename, '.');
+        if(p_last_period == NULL) {
+            /* If there is no period at all, the filename can't have a valid extension. */
+            return_v = FILENAME_HAS_NO_PERIOD;
+        } else {
+            /* There is at least one period... */
+            int per_index = p_last_period - filename;
+            if(per_index == strlen(filename) - 1) {
+                /* If it ends in a '.' it is not a valid filename. */
+                return_v = FILENAME_ENDS_IN_PERIOD;
+            } else {
+                if(p_last_slash > p_last_period) {
+                    /* then the period was in the folder name, not the file name. */
+                    return_v = FILENAME_HAS_NO_PERIOD; 
+                }
+                else if(p_last_period ==(p_last_slash + 1)) {
+                    /* then the file name starts with a period. */
+                    char next_char = *(p_last_period + 1);
+                    if(next_char == '\0') {
+                        return_v = FILENAME_IS_ONLY_PERIOD;
+                    } else {
+                        return_v = per_index;
+                    }
+
+                } else {
+                    return_v = per_index;
+                }
+            }
+        }
+    }
+    return return_v;
+
+}
+
+int filenameHasExtension2(const char * filename) {
     char * pointer_to_last_period = strrchr(filename, '.');
     int return_value = 0;
     if(pointer_to_last_period == NULL) {
@@ -36,12 +107,15 @@ int filenameHasExtension(const char * filename) {
     } else {
         if(pointer_to_last_period == filename) {
             /* If they have the same address, the filename string starts with '.' and is invalid. */
-            return_value = FILENAME_STARTS_WITH_PERIOD;
+            return_value = FILENAME_IS_ONLY_PERIOD;
+            
+            /* if the string starts with a period, we need to make sure that it's not part of a folder name. */
+
         } else {
             char * first_occurence;
             first_occurence = strchr(filename, '.');
             if(first_occurence == filename) {
-                return_value = FILENAME_STARTS_WITH_PERIOD;
+                return_value = FILENAME_IS_ONLY_PERIOD;                
             } else {
                 int period_index = pointer_to_last_period - filename;
                 int string_length = strlen(filename);
@@ -49,8 +123,23 @@ int filenameHasExtension(const char * filename) {
                     /* If the string ended with a period, it is invalid. */
                     return_value = FILENAME_ENDS_IN_PERIOD;
                 } else {
-                    /* Otherwise, the filename is well formed and we can return the index of the period. */
                     return_value = period_index;
+                    /* Ensure that the last '.' was not in a parent folder's name. */
+                    char * pointer_to_slash = strrchr(filename, '/');
+                    if(pointer_to_slash != NULL) {
+                        int forward_slash_index = pointer_to_slash - filename;
+                        if(forward_slash_index > period_index) {
+                            return_value = FILENAME_HAS_NO_PERIOD;
+                        }
+                    }
+                    pointer_to_slash = strrchr(filename, '\\');
+                    if(pointer_to_slash != NULL) {
+                        int back_slash_index = pointer_to_slash - filename;
+                        if(back_slash_index > period_index) {
+                            return_value = FILENAME_HAS_NO_PERIOD;
+                        }
+                    }
+                    /* Otherwise, the filename is well formed and we can return the index of the period. */
                 }
             }
         }
@@ -67,27 +156,76 @@ char * addExtension(const char* filename, const char* extension) {
     return new_string;
 }
 
+char * removeExtension(const char* filename) {
+    int index = filenameHasExtension(filename);
+    size_t allocation_size = sizeof(char) * strlen(filename);
+    char * new_string = (char *) malloc (allocation_size);
+    strncpy(new_string, filename, index);
+    new_string[index] = '\0';
+    return new_string;
+}
+
+
 #pragma endregion filenames
 
 #pragma region prompts
 
 short promptUserOverwriteSelection() {
-    int user_selection = 0;
+
+    char user_selection;
     printf("That file already exists. What would you like to do?\n");
-    printf("(1) : Reenter a filename.\n");
-    printf("(2) : Overwrite the file.\n");
-    printf("(3) : Use the default filename.\n");
-    printf("(4) : Terminate the program.\n");
-    scanf("%d", &user_selection);
-    if(
-        user_selection != USER_OUTPUT_OVERWRITE_REENTER_FILENAME_SELECTED &&
-        user_selection != USER_OUTPUT_OVERWRITE_OVERWRITE_EXISTING_FILE &&
-        user_selection != USER_OUTPUT_OVERWRITE_DEFAULT_FILENAME &&
-        user_selection != USER_OUTPUT_TERMINATE_PROGRAM
-        ) {
-            user_selection = USER_OUTPUT_TERMINATE_INVALID_ENTRY;
-        }
-    return (short) user_selection;
+    printf("(1)/(n)     : Reenter a filename.\n");
+    printf("(2)/(o)     : Overwrite the file.\n");
+    printf("(3)/(enter) : Use the default filename.\n");
+    printf("(4)/(q)     : Terminate the program.\n");
+    short user_pick = USER_OUTPUT_TERMINATE_INVALID_ENTRY;
+    user_selection = getchar();
+
+    if(user_selection == '1' || user_selection == 'n') {
+        user_pick = USER_OUTPUT_OVERWRITE_REENTER_FILENAME_SELECTED;
+    } else if(user_selection == '2' || user_selection == 'o') {
+        user_pick = USER_OUTPUT_OVERWRITE_OVERWRITE_EXISTING_FILE;
+    } else if(user_selection == '3' || user_selection == '\n') {
+        user_pick = USER_OUTPUT_OVERWRITE_DEFAULT_FILENAME;
+    } else if(user_selection == '4' || user_selection == 'q') {
+        user_pick = USER_OUTPUT_TERMINATE_PROGRAM;
+    }
+    return (short) user_pick;
 }
 
 #pragma endregion prompts
+
+
+#pragma region structs
+
+void CompFiles_LoadInputFile(FILE * newInputFile) {
+    if(CompFiles.in != NULL) {
+        fclose(CompFiles.in);
+    }
+    CompFiles.in = newInputFile;
+}
+
+void CompFiles_LoadOutputFile(FILE * newOutputFile) {
+    if(CompFiles.out != NULL) {
+        fclose(CompFiles.out);
+    }
+    CompFiles.out = newOutputFile;
+}
+
+void CompFiles_LoadTempFile(FILE * newTempFile) {
+    if(CompFiles.temp != NULL) {
+        fclose(CompFiles.temp);
+    }
+    CompFiles.temp = newTempFile;
+}
+
+void CompFiles_LoadListingFile(FILE * newListingFile) {
+    if(CompFiles.listing != NULL) {
+        fclose(CompFiles.listing);
+    }
+    CompFiles.temp = newListingFile;
+}
+
+
+
+#pragma endregion structs

--- a/src/file_util.h
+++ b/src/file_util.h
@@ -23,25 +23,53 @@
 
 /*
     CompFile is a globally accesible struct which maintains references to the loaded files.
+
+    It has a number of functions closely associated to it. In that way it is a class-like, but a singleton. There is only one CompFile that ever should exist.
 */
-struct TCompFile {
+struct TCompFiles {
     FILE * in;
     FILE * out;
     FILE * temp;
     FILE * listing;
-
+    char * defaultFilename;
 };
-struct TCompFile CompFile;
+struct TCompFiles CompFiles;
+
+/* CompFiles_LoadInputFile loads a new file pointer as the input file. If there is a file already loaded, it closes that file first. */
+void CompFiles_LoadInputFile(FILE * newInputFile);
+
+/* CompFiles_LoadOutputFile loads a new file pointer as the output file. If there is a file already loaded, it closes that file first. */
+void CompFiles_LoadOutputFile(FILE * newOutputFile);
+
+/* CompFiles_LoadTempFile loads a new file pointer as the temp file. If there is a file already loaded, it closes that file first. */
+void CompFiles_LoadTempFile(FILE * newTempFile);
+
+/* CompFiles_LoadListingFile loads a new file pointer as the listing file. If there is a file already loaded, it closes that file first. */
+void CompFiles_LoadListingFile(FILE * newListingFile);
 
 #pragma endregion structs
 
 /* 
 -------------------------------------------------------------------------------
-                filename functions                                                
+                file operations                                                
 -------------------------------------------------------------------------------
 */
-#pragma region filenames
+#pragma region fileops
 
+/*
+
+    backupFile renames an existing file, adding the extension '.bak' to the end of it. For example 'outFile.out' will become 'outFile.out.bak'.
+
+                    Authors:    klm127
+                    Created On: 1/22/2023
+                    Covered by Unit Tests
+*/
+void backupFile(const char * filename);
+
+enum FILE_EXISTS_ENUM {
+    FILE_EXISTS = 1,
+    FILE_DOES_NOT_EXIST = 0
+};
 /*
     fileExists checks whether a file given by filename exists.
 
@@ -58,6 +86,15 @@ struct TCompFile CompFile;
 */
 short fileExists(const char * filename);
 
+#pragma endregion fileops
+
+/* 
+-------------------
+filename functions                                                
+------------------
+*/
+#pragma region filenames
+
 /*
     The enum FILENAME_EXTENSION_PARSE describes possible return values from filenameHasExtension which indicate different ways which a filename may be invalid.
         no period :         -1
@@ -67,11 +104,12 @@ short fileExists(const char * filename);
 enum FILENAME_EXTENSION_PARSE {
     FILENAME_HAS_NO_PERIOD = -1,
     FILENAME_ENDS_IN_PERIOD = -2,
-    FILENAME_STARTS_WITH_PERIOD = -3
+    FILENAME_IS_ONLY_PERIOD = -3,
+    FILENAME_IS_DIRECTORY = -4
 };
 
 /*
-    filenameHasExtension checks whether a filename has an extension. In other words, it checks whether a string has a '.' preceded and followed by at least one character.
+    filenameHasExtension checks whether a filename has an extension. It validates that a string would be a valid path but with one additional condition: it must have a period in the file name portion of the path followed by at least one character. 
 
     parameters:
         - char * filename : the string to check
@@ -81,7 +119,8 @@ enum FILENAME_EXTENSION_PARSE {
         otherwise, one of the negative FILE_EXTENSION_PARSE enums indicating why the filename is invalid;
             (-1) means there was no period.
             (-2) means it ended in a period.
-            (-3) means it started with a period.
+            (-3) means it is only a period.
+            (-4) means it ends in a slash and is a directory.
 
                     Authors:    klm127
                     Created On: 1/19/2023
@@ -89,7 +128,6 @@ enum FILENAME_EXTENSION_PARSE {
 
 */
 int filenameHasExtension(const char * filename);
-
 
 /*
     addExtension modifies the string given by filename by concatenating the string given by extension.
@@ -106,12 +144,31 @@ int filenameHasExtension(const char * filename);
 */
 char * addExtension(const char* filename, const char* extension);
 
+/*
+    removeExtension modifices the string given in parameters by copying the characters of the string up to the index of the last period.
+
+    PRECONDITION:
+        filename has been validated to have a correct extension (not leading with a '.', not ending with a '.')
+
+    parameters:
+        char * filename - the char array to modfify
+
+    returns:
+        a pointer to a new, extensionless string. This string is allocated with `malloc`. When you are done with it, the memory should be cleared with `free` to avoid memory leaks.
+
+                    Authors:    thomasterh99, klm127
+                    Created On: 1/22/2023
+                    Covered by Unit Tests
+
+*/
+char * removeExtension(const char * filename);
+
 #pragma endregion filenames
 
 /* 
--------------------------------------------------------------------------------
-                prompt functions                                                
--------------------------------------------------------------------------------
+----------------
+prompt functions                                                
+----------------
 */
 #pragma region prompts
 enum USER_OUTPUT_OVERWRITE_SELECTION {
@@ -178,7 +235,7 @@ bool promptFilename(char* inputFilename);
 */
 bool openInputFile(char* inputFilename, FILE* inputFile);
 
-/**
+/*
  * function: void openOutputFile
  * 
  * // todo: describe function

--- a/src/main.c
+++ b/src/main.c
@@ -96,6 +96,7 @@ bool openOutputFile(char* outputFilename, FILE* outputFile) {
 					openOutputFile(outputFilename, outputFile);
 				} else {
 					/*generate the output file from the source file name with the .OUT*/
+
 				}
 				break;
 			case USER_OUTPUT_OVERWRITE_OVERWRITE_EXISTING_FILE:

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -11,8 +11,6 @@
 
 */
 
-CuSuite * StrUtilGetSuite();
-
 /*
     Loads all testing suites, runs the unit tests, and prints the output.
 */


### PR DESCRIPTION
From the changelog:

 - added removeExtension function and tests
 - confirmed getchar will read an 'enter'. 
 - thomas fixed prompting function to accept alternate inputs
 - added backupFile function and tests
 - Included tests for filepaths with directories
 - redid filenameHasExtension. It now allows for filenames like ".bob" and doesnt allow filenames that end in slashes. It does allow folders to have '.'s in them.