### PR TITLE
actually works

### DIFF
--- a/INSTRUCT.txt
+++ b/INSTRUCT.txt
@@ -1,0 +1,32 @@
+The total number of lexical errors will be identified at the end of the listing file.
+The Temp file will not be written to at this time but will be opened and appended to the end of
+the output file then deleted when the program is completed. For now print a message to Temp
+which will be appended to the output file i.e. "The Temp.". Comment out the deletion of the
+Temp file at this time.
+The output file will contain a table consisting of the numeric (enum) token followed by the
+token name and the token buffer (actual text theat identified the token).
+The Listing filename will be constructed from the output filename.
+The main function will open the files and continuously call the scanner receiving the token until
+the SCANEOF token is received.
+The main function will use the token buffer, token, and the line buffer to build the output file and
+listing files.
+For example the program:
+begin -- a program
+a:= BB & A;
+end
+will generate the listing file:
+1 begin -- a program
+2 a:= BB & A;
+Error. & not recognized.
+3 end
+1 Lexical Errors.
+and the output file:
+token number: 0 token type: BEGIN actual token: BEGIN
+token number: 4 token type: ID actual token: A
+token number: 10 token type: ASSIGNOP actual token: :=
+token number: 4 token type: ID actual token: BB
+token number: 14 token type: ERROR actual token: &
+token number: 4 token type: ID actual token: A
+token number: 8 token type: SEMICOLON actual token: ;
+token number: 1 token type: END actual token: END
+token number: 13 token type: SCANEOF actual token: EOF

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,18 @@
+2/13/2023: Karl and thomas
+- fixed listing file not loading
+- fixed extractInt AND extractInt tests (they were using extractWord)!
+- running error count and print errors
+- fixed detect SCANEOF
+- fixed null terminates at end of buffer for no overflow print
+- fixed last line being ignored
+- several types of token catch initializers
+- token catch allocates memory; can use the tokens later in the parser
+- scanner printLine fixes
+- print error count
+- Token_GetOpRaw
+- formatting line printing
+
+
 2/13/2023: All Group Members
 - Extract op
 - Fleshed out the switch statement for take Action

--- a/src/compfiles.c
+++ b/src/compfiles.c
@@ -133,7 +133,7 @@ void CompFiles_LoadListingFile(FILE *newListingFile)
     {
         fclose(CompFiles.listing);
     }
-    CompFiles.temp = newListingFile;
+    CompFiles.listing = newListingFile;
 }
 
 char *CompFiles_promptInputFilename()

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -54,10 +54,8 @@ typedef struct {
     FILE *temp;
     /*! A file pointer to an open listing file. */
     FILE *listing;
-    /*! The buffer of found tokens that will be read by the parser. */
-    TokenCatch* tokens;
-    /*! The length of the tokens array. */
-    int l_tokens;
+    /*! The number of syntax errors found. */
+    int n_errors;
 
 } TScanner;
 
@@ -202,6 +200,32 @@ Scanner printing
 */
 void Scanner_printLine();
 
+/*!
+    Prints information about a token in an output file. 
+
+    It will also print to stdout if the flag is set in the header file.
+
+    If the token is of type error, it also calls Scanner_printError to effect printing to the listing file. 
+
+    \param token A TokenCatch struct containing the token type, raw string, line, and column number of the given token. 
+    \author klm127
+    \date 2/12/2023
+*/
+void Scanner_printToken(struct TokenCatch * token);
+
+/*!
+    Prints an error to the listing file. Includes appropriately indented caret. 
+
+    \param token A TokenCatch struct for an error token, containing the raw string, line, and column number of the given error token.
+    \author klm127
+    \date 2/12/2023
+*/
+void Scanner_printError(struct TokenCatch * token);
+
+/*!
+    Prints the error total to the listing file.
+*/
+void Scanner_PrintErrorCount();
 #pragma endregion printing
 /*
 ----------------

--- a/src/scanner_util.c
+++ b/src/scanner_util.c
@@ -53,25 +53,24 @@ char* extractWord(char* buffer, int * index, char* boundrychars, int l_boundrych
 
 char* extractInt(char* buffer, int* index) {
     int start = *index;
-    int offset = start;
-    char test = buffer[offset];
-    short at_boundry = 0;
-    while(!at_boundry) {
-        at_boundry = test >= '0' && test <= '9';
-        offset+=1;
-        test = buffer[offset];
-    }
-    int size_neword = offset-start+1;
-    char * new_word  = malloc( size_neword * sizeof(char)) ;
+
     int i = 0;
-    while(start < offset - 1) {
-        new_word[i] = buffer[start];
+    char check = buffer[start];
+    while(check >= '0' && check <= '9') {
         i++;
-        start++;
+        check = buffer[start+i];
     }
-    *index = offset - 1;
-    new_word[i] = '\0';
-    return new_word;
+
+    char * newstring = malloc( (i+1) * sizeof(char));
+    
+    int j = 0;
+    while(j < i) {
+        newstring[j] = buffer[start+j];
+        j++;
+    }
+    newstring[j] = '\0';
+    *index += i;
+    return newstring;
 }
 
 short charIn(char test, char* charset, int l_charset) {

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -19,12 +19,12 @@ const char *tokensMap[] = {
     [ENDIF] = "ENDIF",
     [WHILE] = "WHILE",
     [ENDWHILE] = "ENDWHILE",
-
     [ID] = "ID",
     [INTLITERAL] = "INTLITERAL",
     [FALSEOP] = "FALSEOP",
     [TRUEOP] = "TRUEOP",
     [NULLOP] = "NULLOP",
+
     [LPAREN] = "LPAREN",
     [RPAREN] = "RPAREN",
     [SEMICOLON] = "SEMICOLON",
@@ -101,39 +101,96 @@ int Token_RecognizeKeyword(char *word, int length)
     return token;
 }
 
-TokenCatch Token_Catch(short tokenType, char* raw_text_found, int line_found_at, int col_found_at) {
-    TokenCatch tc;
-    tc.token = tokenType;
-    tc.raw = raw_text_found;
-    tc.line_no = line_found_at;
-    tc.col_no = col_found_at;
+struct TokenCatch* Token_Catch(short tokenType, char* raw_text_found, int line_found_at, int col_found_at) {
+    struct TokenCatch* tc = malloc(sizeof (struct TokenCatch));
+    tc->token = tokenType;
+    tc->raw = raw_text_found;
+    tc->line_no = line_found_at;
+    tc->col_no = col_found_at;
     return tc;
 }
 
-
-TokenCatch Token_CatchOp(short tokenType, int line_found_at, int col_found_at) {
-    TokenCatch tc;
-    tc.token = tokenType;
-    const char * tokName;
-    if(tc.token == ERROR) {
-        /* If tok is error, then it MUST have been ':' */
-        tokName = ":";
-    } else {
-        tokName = Token_GetName(tokenType);
+char * Token_GetOpRaw(short tokenType) {
+    char * result;
+    switch(tokenType) {
+        case LPAREN:
+            result = "(";
+            break;
+        case RPAREN:
+            result = ")";
+            break;
+        case SEMICOLON:
+            result = ";";
+            break;
+        case COMMA:
+            result = ",";
+            break;
+        case ASSIGNOP:
+            result = ":=";
+            break;
+        case PLUSOP:
+            result = "+";
+            break;
+        case MINUSOP:
+            result = "-";
+            break;
+        case MULTOP:
+            result = "*";
+            break;
+        case DIVOP:
+            result = "/";
+            break;
+        case NOTOP:
+            result = "!";
+            break;
+        case LESSOP:
+            result = "<";
+            break;
+        case LESSEQUALOP:
+            result = "<=";
+            break;
+        case GREATEROP:
+            result = ">";
+            break;
+        case GREATEREQUALOP:
+            result = ">=";
+            break;
+        case EQUALOP:
+            result = "=";
+            break;
+        case NOTEQUALOP:
+            result = "<>";
+            break;
+        default:
+            result = ":";
     }
-    tc.raw = malloc(strlen(tokName) *sizeof(char));
-    strcpy(tc.raw, tokName);
-    tc.line_no = line_found_at;
-    tc.col_no = col_found_at;
+    char * ret_val = malloc( (strlen(result)+1)*sizeof(char));
+    strcpy(ret_val, result);
+    return ret_val;
+
+}
+
+
+struct TokenCatch* Token_CatchOp(short tokenType, int line_found_at, int col_found_at) {
+    struct TokenCatch* tc = malloc(sizeof(struct TokenCatch));
+    tc->token = tokenType;
+    tc->raw = Token_GetOpRaw(tokenType);
+    tc->line_no = line_found_at;
+    tc->col_no = col_found_at;
     return tc;
 }
 
-TokenCatch Token_CatchError(char badChar, int line_found_at, int col_found_at) {
-    TokenCatch tc;
-    tc.token = ERROR;
-    tc.raw = malloc(2*sizeof(char));
-    tc.raw[0] = badChar;
-    tc.raw[1] = '\0';
-    tc.line_no = line_found_at;
-    tc.col_no = col_found_at;
+struct TokenCatch* Token_CatchError(char badChar, int line_found_at, int col_found_at) {
+    struct TokenCatch* tc = malloc(sizeof(struct TokenCatch));
+    tc->token = ERROR;
+    tc->raw = malloc(2*sizeof(char));
+    tc->raw[0] = badChar;
+    tc->raw[1] = '\0';
+    tc->line_no = line_found_at;
+    tc->col_no = col_found_at;
+}
+
+void Token_Destroy(struct TokenCatch* token) {
+    free(token->raw); /* dealloc the string first. */
+    free(token);
 }

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -7,7 +7,7 @@ enum TOKEN {
     BEGIN=0, END, READ, WRITE, IF, THEN, ELSE, ENDIF, WHILE, ENDWHILE, ID, INTLITERAL, FALSEOP, TRUEOP, NULLOP, LPAREN, RPAREN, SEMICOLON, COMMA, ASSIGNOP, PLUSOP, MINUSOP, MULTOP,DIVOP, NOTOP, LESSOP, LESSEQUALOP, GREATEROP, GREATEREQUALOP, EQUALOP, NOTEQUALOP, SCANEOF, ERROR
 };
 
-typedef struct {
+struct TokenCatch{
     /* A type corresponding to the TOKEN enum. */
     short token;
     /* The character that was found. */
@@ -17,7 +17,7 @@ typedef struct {
     /* The column where it started. */
     int col_no;
 
-} TokenCatch;
+};
 
 /*! Token_GetName gets a character string representing a token. 
 
@@ -25,9 +25,11 @@ typedef struct {
     \return const char* A string from a lookup table, e.g, "BEGIN". If the param is not a valid token, then it returns "NULL".
     \author klm127
     \date 2/7/2023
-    \note Not Covered By Unit Tests
+    \note Covered By Unit Tests
 */
 const char * Token_GetName(int id);
+
+
 
 /*! Token_Recognize recognizes a token from a string parameter and returns the corresponding token id.
     \param word The string to identify.
@@ -35,6 +37,7 @@ const char * Token_GetName(int id);
     \pre The token is only alphanumeric characters and has already been validated not to contain a comment. (Two '--' chars.)
     \pre The token does not contain any valid operators. (It will be recognized as an identifier if so.)
     \return int a integer within the TOKEN enum; ERROR if it was not a valid word.
+    \note Covered by unit tests.
 */
 int Token_RecognizeKeyword(char * word, int length);
 
@@ -47,7 +50,14 @@ int Token_RecognizeKeyword(char * word, int length);
     \param col_found_at The column at which the token was found. 
     \returns A new TokenCatch encapsulating the parameter data. 
 */
-TokenCatch Token_Catch(short tokenType, char* raw_text_found, int line_found_at, int col_found_at);
+struct TokenCatch* Token_Catch(short tokenType, char* raw_text_found, int line_found_at, int col_found_at);
+
+/*! Token_GetOpName gets a malloced string for assignment to raw representing what must have been found for an operator text given an enumerated operarator token. If its not one of the operators, it returns ':', which is the one case when a valid operator character was a syntactic error.
+
+    \param tokenType The operator token enumerated id
+    \return A malloced string containing the operator, e.g. "<=".
+*/
+char * Token_GetOpRaw(short tokenType);
 
 /*!
     Token_Catch_Op is called when an op is found. It still produces a TokenCatch but it infers the text that was found based on the token type rather than needing the raw text, since there is not variation in how the operators can be written.  
@@ -57,7 +67,7 @@ TokenCatch Token_Catch(short tokenType, char* raw_text_found, int line_found_at,
     \param col_found_at The column at which the token was found. 
     \returns A new TokenCatch encapsulating the parameter data. 
 */
-TokenCatch Token_CatchOp(short tokenType, int line_found_at, int col_found_at);
+struct TokenCatch* Token_CatchOp(short tokenType, int line_found_at, int col_found_at);
 
 /*!
     Token_CatchError is called when an error is found. Whatever character is passed in will become the 'raw' member of a TokenCatch. 
@@ -65,8 +75,14 @@ TokenCatch Token_CatchOp(short tokenType, int line_found_at, int col_found_at);
     \param raw_text_found A char pointer to the raw text that caused this token to be identified as such.
     \param line_found_at The line in the file the token was found.
     \param col_found_at The column at which the token was found. 
-    \returns A new TokenCatch encapsulating the parameter data. 
+    \returns A pointer to a malloced TokenCatch encapsulating the parameter data. 
 */
-TokenCatch Token_CatchError(char badChar, int line_found_at, int col_found_at);
+struct TokenCatch* Token_CatchError(char badChar, int line_found_at, int col_found_at);
+
+/*!
+    Token Destroy deallocates a token by first freeing the internal 'raw' string, then deallocating the token itself. 
+    \param token A token to deallocate.
+*/
+void Token_Destroy(struct TokenCatch* token);
 
 #endif

--- a/tests/scanner_test.c
+++ b/tests/scanner_test.c
@@ -9,20 +9,102 @@ void test_Scanner_Init(CuTest *tc){
     CuAssertIntEquals(tc, 17, strlen(scan->boundaries));
 }
 
-void test_Scanner_DeInit(CuTest *tc){
 
-}
 
-void test_Scanner_clearBuffer(CuTest *tc){
+void test_extractOp(CuTest *tc) {
+    printf("Made it here.");
+    fflush(stdout);
 
-}
+    int index = 0;
+    char * buff = "(";
+    int tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, LPAREN, tok );
 
-void test_Scanner_expandBuffer(CuTest *tc){
+    index = 0;
+    buff = ")";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, RPAREN,  tok);
+
+    index = 0;
+    buff = ";";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, SEMICOLON,  tok);
+
+    index = 0;
+    buff = ",";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, COMMA,  tok);
+
+    index = 0;
+    buff = ":=";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, ASSIGNOP,  tok);
+
+    index = 0;
+    buff = "+";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, PLUSOP,  tok);
+
+    index = 0;
+    buff = "-";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, MINUSOP,  tok);
+
+    index = 0;
+    buff = "*";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, MULTOP,  tok);
+
+    index = 0;
+    buff = "/";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, DIVOP,  tok);
+
+    index = 0;
+    buff = "!";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, NOTOP,  tok);
+
+    index = 0;
+    buff = "<+";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, LESSOP,  tok);
+
+    index = 0;
+    buff = "<=";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, LESSEQUALOP,  tok);
+
+    index = 0;
+    buff = ">1";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, GREATEROP,  tok);
+
+    index = 0;
+    buff = ">=";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, GREATEREQUALOP, tok);
+
+    index = 0;
+    buff = "=";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, EQUALOP, tok);
+
+    index = 0;
+    buff = "<>";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, NOTEQUALOP, tok);
+
+    index = 0;
+    buff = "&";
+    tok = extractOperator(buff, &index);
+    CuAssertIntEquals(tc, ERROR, tok);
 
 }
 
 const char * pbtFile = "scn_tbuf_poplate.txt";
 void test_Scanner_populateBuffer(CuTest *tc) {
+    /* TODO: STD Swap*/
     FILE * in = fopen(pbtFile, "w");
     fprintf(in, "Something in a file.\nA new line.\na 160 character linea 160 character linea 160 character linea 160 character linea 160 character linea 160 character linea 160 character line\nSomething else, then the EOF.");
     fclose(in);
@@ -63,18 +145,13 @@ void test_Scanner_populateBuffer(CuTest *tc) {
 
 }
 
-void test_Scanner_addChar(CuTest *tc){
 
-}
-
-void test_Scanner_Scan(CuTest *tc){
-
-}
 
 CuSuite* scannerGetSuite() {
     CuSuite *suite = CuSuiteNew();
-    SUITE_ADD_TEST(suite, test_Scanner_populateBuffer);
+    /* SUITE_ADD_TEST(suite, test_Scanner_populateBuffer); */
     SUITE_ADD_TEST(suite, test_Scanner_Init);
+    SUITE_ADD_TEST(suite, test_extractOp);
     return suite;
 
 }

--- a/tests/scanner_util_test.c
+++ b/tests/scanner_util_test.c
@@ -83,33 +83,33 @@ void test_extractWord(CuTest *tc) {
 }
 
 void test_extractInt(CuTest *tc) {
-    char * boundrychars = "\t+-;* \0";
-    int l_boundry = 6;
-    char* buffer = "1111* 3333 - 55;111 0";
+    char * boundrychars = "\t+-;*() \n\0";
+    int l_boundry = 10;
+    char* buffer = "1111* 3333) - 55;111 0";
 
     int index = 0;
-    char * test = extractWord(buffer, &index, boundrychars, l_boundry);
-    CuAssertStrEquals(tc, "1111\0", test);
+    char * test = extractInt(buffer, &index);
+    CuAssertStrEquals(tc, "1111", test);
     free(test);
 
     index += 2;
-    test = extractWord(buffer, &index, boundrychars, l_boundry);
-    CuAssertStrEquals(tc, "3333\0", test);
+    test = extractInt(buffer, &index);
+    CuAssertStrEquals(tc, "3333", test);
     free(test);
 
-    index += 3;
-    test = extractWord(buffer, &index, boundrychars, l_boundry);
-    CuAssertStrEquals(tc, "55\0", test);
-    free(test);
-
-    index += 1;
-    test = extractWord(buffer, &index, boundrychars, l_boundry);
-    CuAssertStrEquals(tc, "111\0", test);
+    index += 4;
+    test = extractInt(buffer, &index);
+    CuAssertStrEquals(tc, "55", test);
     free(test);
 
     index += 1;
-    test = extractWord(buffer, &index, boundrychars, l_boundry);
-    CuAssertStrEquals(tc, "0\0", test);
+    test = extractInt(buffer, &index);
+    CuAssertStrEquals(tc, "111", test);
+    free(test);
+
+    index += 1;
+    test = extractInt(buffer, &index);
+    CuAssertStrEquals(tc, "0", test);
     free(test);
 
 


### PR DESCRIPTION
2/13/2023: Karl and thomas

    fixed listing file not loading
    fixed extractInt AND extractInt tests (they were using extractWord)!
    running error count and print errors
    fixed detect SCANEOF
    fixed null terminates at end of buffer for no overflow print
    fixed last line being ignored
    several types of token catch initializers
    token catch allocates memory; can use the tokens later in the parser
    scanner printLine fixes
    print error count
    Token_GetOpRaw
    formatting line printing
